### PR TITLE
Fix media link

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ https://github.com/Ekumen-OS/andino/assets/53065142/29951e74-e604-4a6e-80fc-421c
 _Important!: At the moment this package is only working with the simulation. The support for the real robot is forthcoming._
 
 
-## :selfie: Media
+## Media
 
 ### RVIZ Visualization
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The media section contains an emoji that disables auto-scroll when using a link right after the logo. This PR removes the emoji to re-enable auto-scrolling when clicking on the link.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.